### PR TITLE
Handle CONTENT_TYPE and CONTENT_LENGTH headers to be compliant with Rack

### DIFF
--- a/lib/httpi/adapter/rack.rb
+++ b/lib/httpi/adapter/rack.rb
@@ -86,7 +86,17 @@ module HTTPI
 
         env = {}
         @request.headers.each do |header, value|
-          env["HTTP_#{header.gsub('-', '_').upcase}"] = value
+          # The headers CONTENT_TYPE and CONTENT_LENGTH should not have "HTTP_" 
+          # added as a prefix.  For all other headers, add the prefix "HTTP_"
+          # https://github.com/rack/rack/blob/main/SPEC.rdoc#label-HTTP_+Headers
+          normalized = header.gsub('-', '_').upcase
+          key = if normalized == "CONTENT_TYPE" || normalized == "CONTENT_LENGTH"
+                  normalized
+                else
+                  "HTTP_#{normalized}"
+                end
+
+          env[key] = value
         end
 
         response = @client.request(method.to_s.upcase, @request.url.to_s,


### PR DESCRIPTION
For those two headers, we don't add the prefix "HTTP_" before adding them to the rack env hash.

https://github.com/rack/rack/blob/main/SPEC.rdoc#label-HTTP_+Headers